### PR TITLE
add unique identifier to project based on message id and channel id

### DIFF
--- a/app/controllers/slack/events_controller.rb
+++ b/app/controllers/slack/events_controller.rb
@@ -36,7 +36,7 @@ class Slack::EventsController < ApplicationController
 
       inner_ts = inner["ts"]
       return unless channel == forge_channel_id && inner["thread_ts"].blank? && inner_ts.present?
-      return if Project.exists?(slack_message_ts: inner_ts)
+      return if Project.exists?(slack_channel_id: channel, slack_message_ts: inner_ts)
 
       SlackPitchJob.perform_later(
         slack_user_id: inner["user"],

--- a/app/jobs/slack_pitch_job.rb
+++ b/app/jobs/slack_pitch_job.rb
@@ -8,7 +8,7 @@ class SlackPitchJob < ApplicationJob
       return
     end
 
-    existing = Project.find_by(slack_message_ts: message_ts)
+    existing = Project.find_by(slack_channel_id: channel_id, slack_message_ts: message_ts)
     return if existing
 
     parsed = parse_pitch_with_ai(text)
@@ -33,6 +33,11 @@ class SlackPitchJob < ApplicationJob
     project_url = "#{app_url}/projects/#{project.id}"
     post_reply(channel_id, message_ts, "Your pitch for *#{project.name}* has been received and is now pending review! :eyes:\n\nYou'll hear back here once it's been reviewed.\n\n<#{project_url}|View Project>")
     react_to_message(channel_id, message_ts, "eyes")
+  rescue ActiveRecord::RecordNotUnique
+    existing = Project.find_by(slack_channel_id: channel_id, slack_message_ts: message_ts)
+    return if existing
+
+    raise
   rescue StandardError => e
     Rails.logger.error("SlackPitchJob failed: #{e.class}: #{e.message}\n#{e.backtrace&.first(10)&.join("\n")}")
     begin

--- a/db/migrate/20260419083514_add_unique_index_on_slack_message_origin_to_projects.rb
+++ b/db/migrate/20260419083514_add_unique_index_on_slack_message_origin_to_projects.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexOnSlackMessageOriginToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_index :projects,
+      [ :slack_channel_id, :slack_message_ts ],
+      unique: true,
+      where: "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+      name: "index_projects_on_slack_origin"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_094014) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_19_083514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
to prevent duplicate pitches from being created when slack events are retried. 