### PR TITLE
explore: fair-feed ranking + project views

### DIFF
--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -3,9 +3,13 @@ class ExploreController < ApplicationController
 
   def index
     scope = Project.kept.where(hidden: false).includes(:user, :ships)
-      .order(Arel.sql("cover_image_url IS NULL"), created_at: :desc)
     scope = scope.search(params[:query]) if params[:query].present?
-    @pagy, @projects = pagy(scope)
+
+    ranked = scope.fair_feed
+    # Push cover-imageless projects to the bottom while preserving the score order within each group
+    ranked = ranked.partition { |p| p.cover_image_url.present? }.flatten
+
+    @pagy, @projects = pagy(ranked)
 
     render inertia: "Explore/Index", props: {
       projects: @projects.map { |p|
@@ -18,6 +22,7 @@ class ExploreController < ApplicationController
           user_display_name: p.user.display_name,
           user_avatar: p.user.avatar,
           ships_count: p.ships.size,
+          views_count: p.views_count,
           created_at: p.created_at.strftime("%b %d, %Y")
         }
       },

--- a/app/controllers/projects/views_controller.rb
+++ b/app/controllers/projects/views_controller.rb
@@ -1,0 +1,12 @@
+class Projects::ViewsController < ApplicationController
+  def create
+    project = Project.find(params[:project_id])
+    return head :no_content if project.user_id == current_user&.id
+    return head :no_content unless current_user
+
+    ProjectView.find_or_create_by(project: project, user: current_user)
+    head :no_content
+  rescue ActiveRecord::RecordNotUnique
+    head :no_content
+  end
+end

--- a/app/javascript/pages/Explore/Index.tsx
+++ b/app/javascript/pages/Explore/Index.tsx
@@ -12,6 +12,7 @@ interface ExploreProject {
   user_display_name: string
   user_avatar: string
   ships_count: number
+  views_count: number
   created_at: string
 }
 
@@ -90,9 +91,13 @@ export default function ExploreIndex({
                     </div>
 
                     <div className="px-5">
-                      <div className="flex justify-between items-start mb-3">
+                      <div className="flex justify-between items-center mb-3">
                         <span className="text-xs uppercase tracking-widest text-stone-500 bg-[#353534] px-3 py-1 rounded-full">
                           Project
+                        </span>
+                        <span className="inline-flex items-center gap-1 text-xs text-stone-500" title="Views">
+                          <span className="material-symbols-outlined text-sm leading-none">visibility</span>
+                          {project.views_count.toLocaleString()}
                         </span>
                       </div>
 

--- a/app/javascript/pages/Projects/Show.tsx
+++ b/app/javascript/pages/Projects/Show.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useRef } from 'react'
+import { useEffect, useMemo, useState, useRef } from 'react'
 import { router, Link, useForm, usePage } from '@inertiajs/react'
 import Markdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
@@ -56,6 +56,41 @@ function validateDevlogContent(content: string): { valid: boolean; errors: strin
   return { valid: errors.length === 0, errors }
 }
 
+function DevlogContentEditor({ content, children }: { content: string; children: React.ReactNode }) {
+  const [mode, setMode] = useState<'write' | 'preview'>('write')
+  const tabClass = (active: boolean) =>
+    `px-3 py-1.5 text-[10px] uppercase tracking-[0.2em] font-bold cursor-pointer ${
+      active ? 'text-[#ffb595] border-b border-[#ca5924]' : 'text-stone-500 hover:text-stone-300 border-b border-transparent'
+    }`
+
+  return (
+    <div>
+      <div className="flex gap-1 mb-2 border-b border-stone-800">
+        <button type="button" onClick={() => setMode('write')} className={tabClass(mode === 'write')}>
+          Write
+        </button>
+        <button type="button" onClick={() => setMode('preview')} className={tabClass(mode === 'preview')}>
+          Preview
+        </button>
+      </div>
+      <div className={mode === 'write' ? '' : 'hidden'}>{children}</div>
+      {mode === 'preview' && (
+        <div className="bg-[#0e0e0e] px-4 py-3 text-sm min-h-[200px] overflow-auto">
+          {content.trim() ? (
+            <div className="prose prose-invert prose-sm max-w-none text-stone-300 prose-a:text-[#ffb595] prose-img:max-w-full prose-img:rounded-none break-words [overflow-wrap:anywhere]">
+              <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw, rehypeSanitize]}>
+                {content}
+              </Markdown>
+            </div>
+          ) : (
+            <span className="text-stone-600 text-xs italic">Nothing to preview yet.</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 interface DevlogEntry {
   id: number
   title: string
@@ -111,6 +146,16 @@ export default function ProjectsShow({
 }) {
   const [kudoContent, setKudoContent] = useState('')
   const [devlogOrder, setDevlogOrder] = useState<'newest' | 'oldest'>('newest')
+
+  useEffect(() => {
+    const csrf = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? ''
+    fetch(`/projects/${project.id}/view`, {
+      method: 'POST',
+      headers: { 'X-CSRF-Token': csrf },
+      credentials: 'same-origin',
+      keepalive: true,
+    }).catch(() => {})
+  }, [project.id])
 
   function submitKudo(e: React.FormEvent) {
     e.preventDefault()
@@ -876,29 +921,31 @@ export default function ProjectsShow({
                     <label className="block text-xs font-bold uppercase tracking-[0.2em] text-stone-500 mb-2">
                       Content <span className="text-stone-600 normal-case tracking-normal">(markdown supported)</span>
                     </label>
-                    <textarea
-                      value={devlogForm.data.content}
-                      onChange={(e) => {
-                        devlogForm.setData('content', e.target.value)
-                        const { errors } = validateDevlogContent(e.target.value)
-                        setDevlogValidationErrors(errors)
-                      }}
-                      onPaste={(e) =>
-                        handleImagePaste(
-                          e,
-                          (v) => {
-                            devlogForm.setData('content', v)
-                            const { errors } = validateDevlogContent(v)
-                            setDevlogValidationErrors(errors)
-                          },
-                          devlogForm.data.content,
-                        )
-                      }
-                      rows={8}
-                      className="w-full bg-[#0e0e0e] border-none px-4 py-3 text-[#e5e2e1] focus:ring-1 focus:ring-[#ca5924]/30 placeholder:text-stone-600 text-sm resize-y font-mono"
-                      placeholder="What did you work on? Paste images directly..."
-                      required
-                    />
+                    <DevlogContentEditor content={devlogForm.data.content}>
+                      <textarea
+                        value={devlogForm.data.content}
+                        onChange={(e) => {
+                          devlogForm.setData('content', e.target.value)
+                          const { errors } = validateDevlogContent(e.target.value)
+                          setDevlogValidationErrors(errors)
+                        }}
+                        onPaste={(e) =>
+                          handleImagePaste(
+                            e,
+                            (v) => {
+                              devlogForm.setData('content', v)
+                              const { errors } = validateDevlogContent(v)
+                              setDevlogValidationErrors(errors)
+                            },
+                            devlogForm.data.content,
+                          )
+                        }
+                        rows={8}
+                        className="w-full bg-[#0e0e0e] border-none px-4 py-3 text-[#e5e2e1] focus:ring-1 focus:ring-[#ca5924]/30 placeholder:text-stone-600 text-sm resize-y font-mono"
+                        placeholder="What did you work on? Paste images directly..."
+                        required
+                      />
+                    </DevlogContentEditor>
                     <div className="text-xs text-stone-400 mt-2 flex items-center justify-between">
                       <span>
                         {devlogValidationErrors.length === 0
@@ -990,28 +1037,30 @@ export default function ProjectsShow({
                               Content{' '}
                               <span className="text-stone-600 normal-case tracking-normal">(markdown supported)</span>
                             </label>
-                            <textarea
-                              value={editDevlogForm.data.content}
-                              onChange={(e) => {
-                                editDevlogForm.setData('content', e.target.value)
-                                const { errors } = validateDevlogContent(e.target.value)
-                                setEditDevlogValidationErrors(errors)
-                              }}
-                              onPaste={(e) =>
-                                handleImagePaste(
-                                  e,
-                                  (v) => {
-                                    editDevlogForm.setData('content', v)
-                                    const { errors } = validateDevlogContent(v)
-                                    setEditDevlogValidationErrors(errors)
-                                  },
-                                  editDevlogForm.data.content,
-                                )
-                              }
-                              rows={8}
-                              className="w-full bg-[#0e0e0e] border-none px-4 py-3 text-[#e5e2e1] focus:ring-1 focus:ring-[#ca5924]/30 placeholder:text-stone-600 text-sm resize-y font-mono"
-                              required
-                            />
+                            <DevlogContentEditor content={editDevlogForm.data.content}>
+                              <textarea
+                                value={editDevlogForm.data.content}
+                                onChange={(e) => {
+                                  editDevlogForm.setData('content', e.target.value)
+                                  const { errors } = validateDevlogContent(e.target.value)
+                                  setEditDevlogValidationErrors(errors)
+                                }}
+                                onPaste={(e) =>
+                                  handleImagePaste(
+                                    e,
+                                    (v) => {
+                                      editDevlogForm.setData('content', v)
+                                      const { errors } = validateDevlogContent(v)
+                                      setEditDevlogValidationErrors(errors)
+                                    },
+                                    editDevlogForm.data.content,
+                                  )
+                                }
+                                rows={8}
+                                className="w-full bg-[#0e0e0e] border-none px-4 py-3 text-[#e5e2e1] focus:ring-1 focus:ring-[#ca5924]/30 placeholder:text-stone-600 text-sm resize-y font-mono"
+                                required
+                              />
+                            </DevlogContentEditor>
                           </div>
                           <div className="text-xs text-stone-400 flex items-center justify-between">
                             <span>

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -27,7 +27,7 @@ class Kudo < ApplicationRecord
 
   belongs_to :user
   belongs_to :author, class_name: "User"
-  belongs_to :project, optional: true
+  belongs_to :project, optional: true, counter_cache: :kudos_count
 
   validates :content, presence: true
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,6 +13,7 @@
 #  discarded_at                 :datetime
 #  green_flags                  :string           default([]), is an Array
 #  hidden                       :boolean          default(FALSE), not null
+#  kudos_count                  :integer          default(0), not null
 #  name                         :string           not null
 #  override_hours               :decimal(, )
 #  override_hours_justification :text
@@ -29,6 +30,7 @@
 #  subtitle                     :string
 #  tags                         :string           default([]), not null, is an Array
 #  tier                         :string           default("tier_4"), not null
+#  views_count                  :integer          default(0), not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  reviewer_id                  :bigint
@@ -65,6 +67,7 @@ class Project < ApplicationRecord
   has_many :project_notes, dependent: :destroy
   has_many :reels, dependent: :destroy
   has_many :review_sessions, dependent: :destroy
+  has_many :project_views, dependent: :destroy
   has_one_attached :cover_image
 
   after_commit :sync_to_airtable, on: [ :create, :update ], if: -> { approved? }
@@ -87,6 +90,21 @@ class Project < ApplicationRecord
 
   scope :reviewable, -> { where(status: :pending) }
   scope :staff_picks, -> { where.not(staff_pick_at: nil).order(staff_pick_at: :desc) }
+
+  def self.fair_feed
+    all.sort_by { |p| -p.feed_score }
+  end
+
+  def feed_score
+    age_hours = [ (Time.current - created_at) / 1.hour, 0.1 ].max
+    engagement = views_count + (kudos_count * 10) + (ships.size * 5)
+    engagement_rate = engagement / age_hours
+
+    freshness = age_hours < 24 ? (5.0 - (4.0 * age_hours / 24)) : 1.0
+
+    base = engagement_rate * freshness
+    base * (1.0 + rand * 0.3)
+  end
 
   def staff_pick?
     staff_pick_at.present?

--- a/app/models/project_view.rb
+++ b/app/models/project_view.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: project_views
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_project_views_on_project_id              (project_id)
+#  index_project_views_on_project_id_and_user_id  (project_id,user_id) UNIQUE
+#  index_project_views_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class ProjectView < ApplicationRecord
+  belongs_to :project, counter_cache: :views_count
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :project_id }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -426,6 +426,7 @@ Rails.application.routes.draw do
     end
     resources :devlogs, only: [ :show, :create, :update, :destroy ]
     post "devlog_image" => "devlogs#upload_image", as: :devlog_image
+    resource :view, only: [ :create ], module: :projects, controller: "views"
     resources :reels, only: [ :new, :create ] do
       collection do
         get "", action: :manage, as: ""

--- a/db/migrate/20260513080424_add_engagement_counters_to_projects.rb
+++ b/db/migrate/20260513080424_add_engagement_counters_to_projects.rb
@@ -1,0 +1,16 @@
+class AddEngagementCountersToProjects < ActiveRecord::Migration[8.1]
+  def up
+    add_column :projects, :views_count, :integer, default: 0, null: false
+    add_column :projects, :kudos_count, :integer, default: 0, null: false
+
+    execute <<~SQL
+      UPDATE projects p
+      SET kudos_count = (SELECT COUNT(*) FROM kudos k WHERE k.project_id = p.id)
+    SQL
+  end
+
+  def down
+    remove_column :projects, :kudos_count
+    remove_column :projects, :views_count
+  end
+end

--- a/db/migrate/20260513080439_create_project_views.rb
+++ b/db/migrate/20260513080439_create_project_views.rb
@@ -1,0 +1,12 @@
+class CreateProjectViews < ActiveRecord::Migration[8.1]
+  def change
+    create_table :project_views do |t|
+      t.references :project, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :project_views, [ :project_id, :user_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_115706) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_080439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -238,6 +238,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_115706) do
     t.index ["project_id"], name: "index_project_notes_on_project_id"
   end
 
+  create_table "project_views", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "project_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["project_id", "user_id"], name: "index_project_views_on_project_id_and_user_id", unique: true
+    t.index ["project_id"], name: "index_project_views_on_project_id"
+    t.index ["user_id"], name: "index_project_views_on_user_id"
+  end
+
   create_table "projects", force: :cascade do |t|
     t.text "approval_justification"
     t.text "budget"
@@ -250,6 +260,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_115706) do
     t.datetime "discarded_at"
     t.string "green_flags", default: [], array: true
     t.boolean "hidden", default: false, null: false
+    t.integer "kudos_count", default: 0, null: false
     t.string "name", null: false
     t.decimal "override_hours"
     t.text "override_hours_justification"
@@ -270,6 +281,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_115706) do
     t.string "tier", default: "tier_4", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.integer "views_count", default: 0, null: false
     t.index ["discarded_at"], name: "index_projects_on_discarded_at"
     t.index ["staff_pick_at"], name: "index_projects_on_staff_pick_at"
     t.index ["status"], name: "index_projects_on_status"
@@ -699,6 +711,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_115706) do
   add_foreign_key "orders", "users", column: "reviewer_id"
   add_foreign_key "project_notes", "projects"
   add_foreign_key "project_notes", "users", column: "author_id"
+  add_foreign_key "project_views", "projects"
+  add_foreign_key "project_views", "users"
   add_foreign_key "projects", "users"
   add_foreign_key "projects", "users", column: "reviewer_id"
   add_foreign_key "reel_comments", "reel_comments", column: "parent_id", on_delete: :cascade

--- a/test/fixtures/project_views.yml
+++ b/test/fixtures/project_views.yml
@@ -1,0 +1,30 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# == Schema Information
+#
+# Table name: project_views
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_project_views_on_project_id              (project_id)
+#  index_project_views_on_project_id_and_user_id  (project_id,user_id) UNIQUE
+#  index_project_views_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (user_id => users.id)
+#
+one:
+  project: one
+  user: one
+
+two:
+  project: two
+  user: two

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -15,6 +15,7 @@
 #  discarded_at                 :datetime
 #  green_flags                  :string           default([]), is an Array
 #  hidden                       :boolean          default(FALSE), not null
+#  kudos_count                  :integer          default(0), not null
 #  name                         :string           not null
 #  override_hours               :decimal(, )
 #  override_hours_justification :text
@@ -31,6 +32,7 @@
 #  subtitle                     :string
 #  tags                         :string           default([]), not null, is an Array
 #  tier                         :string           default("tier_4"), not null
+#  views_count                  :integer          default(0), not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  reviewer_id                  :bigint

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -13,6 +13,7 @@
 #  discarded_at                 :datetime
 #  green_flags                  :string           default([]), is an Array
 #  hidden                       :boolean          default(FALSE), not null
+#  kudos_count                  :integer          default(0), not null
 #  name                         :string           not null
 #  override_hours               :decimal(, )
 #  override_hours_justification :text
@@ -29,6 +30,7 @@
 #  subtitle                     :string
 #  tags                         :string           default([]), not null, is an Array
 #  tier                         :string           default("tier_4"), not null
+#  views_count                  :integer          default(0), not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  reviewer_id                  :bigint

--- a/test/models/project_view_test.rb
+++ b/test/models/project_view_test.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: project_views
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_project_views_on_project_id              (project_id)
+#  index_project_views_on_project_id_and_user_id  (project_id,user_id) UNIQUE
+#  index_project_views_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require "test_helper"
+
+class ProjectViewTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Ports the reels fair-feed algorithm to projects (views/kudos/ships engagement, freshness boost, jitter) and uses it to rank the Explore grid instead of created_at. Adds a project_views table + counter cache on projects, tracks one view per signed-in non-owner on the project page, and shows the view count on each Explore card.