### PR TITLE
Scope AI check requirements to project tier

### DIFF
--- a/app/services/ai_requirements_checker.rb
+++ b/app/services/ai_requirements_checker.rb
@@ -40,6 +40,7 @@ module AiRequirementsChecker
     requirements = list_requirements(config)
     raise Error, "Could not extract any requirements from the rubric." if requirements.empty?
 
+    requirements = requirements_for_tier(requirements, project.tier)
     evaluated = evaluate_all(requirements, project, config)
 
     {
@@ -52,8 +53,18 @@ module AiRequirementsChecker
     }
   end
 
+  # Keep tiers an explicit subset of a requirement only when the docs gate it
+  # (e.g. pitches are Tier 1 only). An empty array means "applies to every tier".
+  def requirements_for_tier(requirements, tier)
+    tier_number = tier.to_s[/\d+/]&.to_i
+    requirements.select do |req|
+      tiers = Array(req["tiers"])
+      tiers.empty? || tier_number.nil? || tiers.include?(tier_number)
+    end
+  end
+
   def list_requirements(config)
-    Rails.cache.fetch([ "ai_requirements_checker", "requirement_list", docs_digest, config[:model] ], expires_in: 12.hours) do
+    Rails.cache.fetch([ "ai_requirements_checker", "requirement_list", "v2", docs_digest, config[:model] ], expires_in: 12.hours) do
       fetch_requirement_list(config)
     end
   end
@@ -72,7 +83,8 @@ module AiRequirementsChecker
       {
         "name" => name.truncate(120),
         "source" => req["source"].to_s.truncate(80),
-        "criterion" => req["criterion"].to_s.truncate(400)
+        "criterion" => req["criterion"].to_s.truncate(400),
+        "tiers" => Array(req["tiers"]).filter_map { |t| Integer(t, exception: false) }
       }
     end
   end
@@ -161,9 +173,10 @@ module AiRequirementsChecker
         - name: short neutral name, under 8 words
         - source: the doc filename it came from (e.g. "submitting.md")
         - criterion: one sentence describing exactly what the project must have or do to pass this requirement
+        - tiers: project tiers this requirement applies to, as numbers 1-4. Use an empty array [] when it applies to every tier. ONLY list specific tiers when the docs explicitly gate it (e.g. "you are only required to pitch for Tier 1 projects" → [1]). Note tier 1 is the most advanced, tier 4 the simplest.
 
       Respond in valid JSON only, no markdown fences:
-      {"requirements": [{"name": "...", "source": "...", "criterion": "..."}]}
+      {"requirements": [{"name": "...", "source": "...", "criterion": "...", "tiers": []}]}
     PROMPT
   end
 


### PR DESCRIPTION
The AI check failed tier 2/3/4 projects on "Structured Slack Pitch" — but pitching.md says pitches are only required for Tier 1. The checker extracted every requirement from the docs and ran all of them against every project regardless of tier.

Fix: the extraction step now tags each requirement with the tiers it applies to (empty = all), and the checker filters to the project's tier before evaluating. Pitch comes back as tiers [1], so it's dropped for tier 2-4 and kept for tier 1.

Verified on dev: extractor tags "Slack project pitch" → [1]; tier_3 yields 15 requirements with no pitch, tier_1 yields 16 with the pitch. Bumped the requirement-list cache key to v2 so the new tiers field takes effect immediately.