### PR TITLE
show internal justifications + tier/funding changes in review timeline

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -500,8 +500,6 @@ class Admin::ProjectsController < Admin::ApplicationController
 
   def justification_fields(reasoning:, feedback:)
     {
-      hackatime_project: params[:hackatime_project],
-      time_range: params[:time_range],
       time_summary: params[:time_summary],
       scope_reasoning: params[:scope_reasoning],
       evidence: params[:evidence],

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -73,7 +73,7 @@ class Admin::ProjectsController < Admin::ApplicationController
     render inertia: "Admin/Projects/Show", props: {
       project: serialize_project_detail(@project),
       notes: @notes.map { |n| serialize_note(n) },
-      review_history: @project.review_history.map { |e| serialize_review_event(e) },
+      review_history: @project.admin_review_history.map { |e| serialize_review_event(e) },
       airtable_status: airtable_status,
       can: { review: policy(@project).review?, destroy: policy(@project).destroy?, restore: policy(@project).restore?, reverse: policy(@project).review? && %w[approved returned rejected].include?(@project.status) }
     }
@@ -343,7 +343,15 @@ class Admin::ProjectsController < Admin::ApplicationController
           cascade_target&.update!(built_at: Time.current)
         end
         end_active_review_session(decision: "approved")
-        audit!("project.approved", target: @project, metadata: { feedback: feedback, override_hours: capped, reasoning: reasoning, build_review: @project.build_review })
+        audit!("project.approved", target: @project, metadata: {
+          feedback: feedback,
+          override_hours: capped,
+          reasoning: reasoning,
+          build_review: @project.build_review,
+          justification: justification,
+          approved_hours: approved_hours.to_f,
+          coins_awarded: @project.coins_awarded.to_f
+        })
         if cascade_target
           audit!("project.marked_built", target: cascade_target, metadata: { via: "build_review", build_review_id: @project.id })
         end
@@ -670,6 +678,13 @@ class Admin::ProjectsController < Admin::ApplicationController
       action: event.action,
       stage: meta["stage"],
       feedback: meta["feedback"].presence || meta["reason"].presence,
+      internal_justification: meta["justification"].presence || meta["reasoning"].presence,
+      old_tier: meta["old_tier"],
+      new_tier: meta["new_tier"],
+      approved_hours: meta["approved_hours"],
+      override_hours: meta["override_hours"],
+      coins_awarded: meta["coins_awarded"],
+      refunded_coins: meta["refunded"] ? meta["previous_coins_earned"] : nil,
       reviewer_display_name: event.actor&.display_name,
       reviewer_avatar: event.actor&.avatar,
       target_type: event.target_type,

--- a/app/controllers/admin/reviews_controller.rb
+++ b/app/controllers/admin/reviews_controller.rb
@@ -27,7 +27,7 @@ class Admin::ReviewsController < Admin::ApplicationController
 
     render inertia: "Admin/Reviews/Show", props: {
       project: serialize_project_for_review(@project),
-      review_history: @project.review_history.map { |e| serialize_review_event(e) },
+      review_history: @project.admin_review_history.map { |e| serialize_review_event(e) },
       notes: @project.project_notes.includes(:author).order(created_at: :desc).map { |n| serialize_note(n) },
       session: @session ? serialize_session(@session) : nil,
       concurrent_reviewers: concurrent,
@@ -232,6 +232,13 @@ class Admin::ReviewsController < Admin::ApplicationController
       action: event.action,
       stage: meta["stage"],
       feedback: meta["feedback"].presence || meta["reason"].presence,
+      internal_justification: meta["justification"].presence || meta["reasoning"].presence,
+      old_tier: meta["old_tier"],
+      new_tier: meta["new_tier"],
+      approved_hours: meta["approved_hours"],
+      override_hours: meta["override_hours"],
+      coins_awarded: meta["coins_awarded"],
+      refunded_coins: meta["refunded"] ? meta["previous_coins_earned"] : nil,
       reviewer_display_name: event.actor&.display_name,
       reviewer_avatar: event.actor&.avatar,
       target_type: event.target_type,

--- a/app/javascript/components/admin/AdminReviewTimeline.tsx
+++ b/app/javascript/components/admin/AdminReviewTimeline.tsx
@@ -13,6 +13,9 @@ import {
   Info,
   Send,
   RotateCcw,
+  ArrowRightLeft,
+  Coins,
+  Lock,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
@@ -21,6 +24,13 @@ export interface ReviewEvent {
   action: string
   stage: string | null
   feedback: string | null
+  internal_justification: string | null
+  old_tier: string | null
+  new_tier: string | null
+  approved_hours: number | null
+  override_hours: number | null
+  coins_awarded: number | null
+  refunded_coins: number | null
   reviewer_display_name: string | null
   reviewer_avatar: string | null
   target_type: string | null
@@ -41,6 +51,17 @@ const ACTION_CONFIG: Record<string, { label: string; color: string; icon: Lucide
   'project.build_rejected': { label: 'Build Rejected', color: 'text-red-600 dark:text-red-400', icon: XCircle },
   'devlog.approved': { label: 'Devlog Approved', color: 'text-emerald-600 dark:text-emerald-400', icon: CheckCircle2 },
   'devlog.returned': { label: 'Devlog Returned', color: 'text-amber-600 dark:text-amber-400', icon: Undo2 },
+  'project.tier_changed': { label: 'Tier Changed', color: 'text-sky-600 dark:text-sky-400', icon: ArrowRightLeft },
+}
+
+function fundingSummary(event: ReviewEvent): string | null {
+  const parts: string[] = []
+  if (event.approved_hours != null) {
+    parts.push(`${Number(event.approved_hours).toFixed(1)} hrs approved${event.override_hours != null ? ' (override)' : ''}`)
+  }
+  if (event.coins_awarded != null) parts.push(`${Number(event.coins_awarded).toFixed(2)} coins awarded`)
+  if (event.refunded_coins != null) parts.push(`${Number(event.refunded_coins).toFixed(2)} coins refunded`)
+  return parts.length ? parts.join(' · ') : null
 }
 
 export default function AdminReviewTimeline({
@@ -73,6 +94,7 @@ export default function AdminReviewTimeline({
           {events.map((event) => {
             const cfg = ACTION_CONFIG[event.action] || { label: event.action, color: 'text-muted-foreground', icon: Info }
             const Icon = cfg.icon
+            const funding = fundingSummary(event)
             return (
               <li key={event.id} className="p-3 flex gap-3">
                 <Icon className={`size-4 shrink-0 mt-0.5 ${cfg.color}`} />
@@ -91,10 +113,32 @@ export default function AdminReviewTimeline({
                     <span>·</span>
                     <span>{event.created_at}</span>
                   </div>
+                  {event.old_tier && event.new_tier && (
+                    <div className="text-sm mt-1.5 capitalize">
+                      {event.old_tier.replace('_', ' ')} → {event.new_tier.replace('_', ' ')}
+                    </div>
+                  )}
+                  {funding && (
+                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-1.5">
+                      <Coins className="size-3 shrink-0" />
+                      <span>{funding}</span>
+                    </div>
+                  )}
                   {event.feedback && (
                     <div className="markdown-content text-sm mt-2">
                       <Markdown remarkPlugins={[remarkGfm]}>{event.feedback}</Markdown>
                     </div>
+                  )}
+                  {event.internal_justification && (
+                    <details className="mt-2 rounded-md border border-dashed border-border bg-muted/30">
+                      <summary className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-muted-foreground cursor-pointer select-none">
+                        <Lock className="size-3 shrink-0" />
+                        Internal justification
+                      </summary>
+                      <div className="markdown-content text-sm px-2.5 pb-2">
+                        <Markdown remarkPlugins={[remarkGfm]}>{event.internal_justification}</Markdown>
+                      </div>
+                    </details>
                   )}
                 </div>
               </li>

--- a/app/javascript/lib/justificationPreview.ts
+++ b/app/javascript/lib/justificationPreview.ts
@@ -13,8 +13,6 @@ export interface JustificationContext {
   devlog_count: number
   public_url: string
   admin_url: string
-  hackatime_project: string
-  time_range: string
   time_summary: string
   scope_reasoning: string
   evidence: string
@@ -31,15 +29,6 @@ function formatHours(value: number): string {
   const rounded = Math.round(value * 10) / 10
   const whole = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1)
   return `${whole}h`
-}
-
-function timeEvidence(ctx: JustificationContext): string {
-  if (ctx.kind === 'build') return present(ctx.time_summary)
-  return [
-    `Hackatime project: ${present(ctx.hackatime_project)}`,
-    `Range analyzed: ${present(ctx.time_range)}`,
-    present(ctx.time_summary),
-  ].join('\n')
 }
 
 function supportingEvidence(ctx: JustificationContext): string {
@@ -77,7 +66,7 @@ This project was approved at ${approved}
 3. A final check was done by Aarav (aarav@hackclub.com) and Souptik (Lead reviewer for forge), who is knowledgeable in hardware, to ensure nothing was missed prior, and that the projects meets our standards in terms of quality.
 
 Time evidence:
-${timeEvidence(ctx)}
+${present(ctx.time_summary)}
 
 Scope assessment:
 ${present(ctx.scope_reasoning)}

--- a/app/javascript/pages/Admin/Reviews/Show.tsx
+++ b/app/javascript/pages/Admin/Reviews/Show.tsx
@@ -452,8 +452,6 @@ export default function AdminReviewsShow({
   }, [project.id, track])
 
   const [reasoning, setReasoning] = useState('')
-  const [hackatimeProject, setHackatimeProject] = useState('')
-  const [timeRange, setTimeRange] = useState('')
   const [timeSummary, setTimeSummary] = useState('')
   const [scopeReasoning, setScopeReasoning] = useState('')
   const [evidence, setEvidence] = useState('')
@@ -562,8 +560,6 @@ export default function AdminReviewsShow({
         devlog_count: project.devlogs.length,
         public_url: `${origin}/projects/${project.id}`,
         admin_url: `${origin}/admin/projects/${project.id}`,
-        hackatime_project: hackatimeProject,
-        time_range: timeRange,
         time_summary: timeSummary,
         scope_reasoning: scopeReasoning,
         evidence,
@@ -576,8 +572,6 @@ export default function AdminReviewsShow({
       claimedHours,
       approvedHours,
       origin,
-      hackatimeProject,
-      timeRange,
       timeSummary,
       scopeReasoning,
       evidence,
@@ -606,8 +600,6 @@ export default function AdminReviewsShow({
           return
         }
         payload.reasoning = reasoning.trim()
-        payload.hackatime_project = hackatimeProject.trim() || null
-        payload.time_range = timeRange.trim() || null
         payload.time_summary = timeSummary.trim() || null
         payload.scope_reasoning = scopeReasoning.trim() || null
         payload.evidence = evidence.trim() || null
@@ -637,8 +629,6 @@ export default function AdminReviewsShow({
     [
       project.id,
       reasoning,
-      hackatimeProject,
-      timeRange,
       timeSummary,
       scopeReasoning,
       evidence,
@@ -1063,52 +1053,19 @@ export default function AdminReviewsShow({
                   </span>
                 </div>
                 <p className="text-[11px] text-muted-foreground -mt-1">
-                  Internal Unified DB record. REMEMBER if this is not good we will get fined. Someone who does not know hardware should be able to check and understand the justification you gave
+                  Internal Unified DB record. REMEMBER if this is not good we will get fined. Someone who does not know
+                  hardware should be able to check and understand the justification you gave
                 </p>
 
-                {project.build_review ? (
-                  <div className="space-y-1.5">
-                    <label className="text-xs text-muted-foreground">Time evidence (journal / timelapse)</label>
-                    <Textarea
-                      value={timeSummary}
-                      onChange={(e) => setTimeSummary(e.target.value)}
-                      placeholder="e.g. Timelapse/journal at <journal url> shows x build sessions: soldering, wiring, firmware. Pace consistent with 12h."
-                      className="h-20 text-sm"
-                    />
-                  </div>
-                ) : (
-                  <>
-                    <div className="grid grid-cols-2 gap-2">
-                      <div className="space-y-1.5">
-                        <label className="text-xs text-muted-foreground">Hackatime project</label>
-                        <Input
-                          value={hackatimeProject}
-                          onChange={(e) => setHackatimeProject(e.target.value)}
-                          placeholder="trivia-game"
-                          className="h-8 text-sm"
-                        />
-                      </div>
-                      <div className="space-y-1.5">
-                        <label className="text-xs text-muted-foreground">Range analyzed</label>
-                        <Input
-                          value={timeRange}
-                          onChange={(e) => setTimeRange(e.target.value)}
-                          placeholder="Feb 3 – Feb 17"
-                          className="h-8 text-sm"
-                        />
-                      </div>
-                    </div>
-                    <div className="space-y-1.5">
-                      <label className="text-xs text-muted-foreground">Hackatime data summary</label>
-                      <Textarea
-                        value={timeSummary}
-                        onChange={(e) => setTimeSummary(e.target.value)}
-                        placeholder="e.g. 14.2h tracked. Heartbeat pattern consistent with active development, no scripted bursts."
-                        className="h-16 text-sm"
-                      />
-                    </div>
-                  </>
-                )}
+                <div className="space-y-1.5">
+                  <label className="text-xs text-muted-foreground">Time evidence (journal / commits / timelapse)</label>
+                  <Textarea
+                    value={timeSummary}
+                    onChange={(e) => setTimeSummary(e.target.value)}
+                    placeholder="What the journal entries, GitHub commits and (if any) timelapse show, and the period covered. e.g. 9 journal entries Feb 3–17 + 47 commits; pace consistent with the hours."
+                    className="h-20 text-sm"
+                  />
+                </div>
 
                 <div className="space-y-1.5">
                   <label className="text-xs text-muted-foreground">Scope assessment</label>

--- a/app/lib/justification_template.rb
+++ b/app/lib/justification_template.rb
@@ -65,7 +65,7 @@ class JustificationTemplate
       project_approval_time: project_approval_time,
       reviewer_name: reviewer_name,
       reviewer_email: reviewer_email.present? ? " (#{reviewer_email})" : "",
-      time_evidence: time_evidence(ship_type, fields),
+      time_evidence: present(fields[:time_summary]),
       scope_reasoning: present(fields[:scope_reasoning]),
       supporting_evidence: supporting_evidence(project, fields),
       claimed_hours: format_hours(claimed_hours),
@@ -75,16 +75,6 @@ class JustificationTemplate
       review_justification: fields[:assessment].to_s.strip.presence || "(no justification provided)",
       forge_admin_link: forge_admin_link
     )
-  end
-
-  def self.time_evidence(ship_type, fields)
-    if ship_type == "build"
-      present(fields[:time_summary])
-    else
-      [ "Hackatime project: #{present(fields[:hackatime_project])}",
-        "Range analyzed: #{present(fields[:time_range])}",
-        present(fields[:time_summary]) ].join("\n")
-    end
   end
 
   def self.supporting_evidence(project, fields)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -197,13 +197,19 @@ class Project < ApplicationRecord
     devlog.approved devlog.returned
   ].freeze
 
-  def review_history
+  ADMIN_REVIEW_EVENT_ACTIONS = (REVIEW_EVENT_ACTIONS + %w[project.tier_changed]).freeze
+
+  def review_history(actions: REVIEW_EVENT_ACTIONS)
     AuditEvent
       .includes(:actor)
-      .where(action: REVIEW_EVENT_ACTIONS)
+      .where(action: actions)
       .where("(target_type = 'Project' AND target_id = :id) OR (metadata @> :meta::jsonb)",
              id: id, meta: { project_id: id }.to_json)
       .order(created_at: :desc)
+  end
+
+  def admin_review_history
+    review_history(actions: ADMIN_REVIEW_EVENT_ACTIONS)
   end
 
   private

--- a/app/services/ai_requirements_checker.rb
+++ b/app/services/ai_requirements_checker.rb
@@ -92,14 +92,14 @@ module AiRequirementsChecker
     justification = payload["Optional - Override Hours Spent Justification"].to_s
     hours = payload["Optional - Override Hours Spent"]
     project = item.project
-    kind = project&.build_review? ? "build review (journaling + timelapse, not Hackatime)" : "design review (Hackatime-tracked)"
+    kind = project&.build_review? ? "build review" : "design review"
 
     <<~PROMPT
       You are auditing a Hack Club Forge "Override Hours Spent Justification" before it enters the YSWS Unified Database. This text is an INTERNAL reviewer record. Judge ONLY the justification text against the standard below — do not re-review the project itself.
 
       ## The standard — a compliant justification must
       1. Specific and verifiable — cite concrete numbers and links another reviewer could independently check.
-      2. Time evidence stated — for a design review, the Hackatime project name + the date range analysed + a summary of what the data shows; for a build review, journaling + timelapse evidence.
+      2. Time evidence stated — what the journal/devlog entries and GitHub commit history (and timelapse, if provided) show, including the period covered. Forge time is journal-tracked, not Hackatime.
       3. Hour adjustment documented — if approved hours are lower than claimed, it states the claimed hours, the approved hours, and the reason for the deflation.
       4. Scope justified — explains what was built and why the scope is consistent with the approved hours.
       5. Factual internal record — NOT encouragement, praise, or a message addressed to the submitter.

--- a/app/services/ai_requirements_checker.rb
+++ b/app/services/ai_requirements_checker.rb
@@ -92,14 +92,14 @@ module AiRequirementsChecker
     justification = payload["Optional - Override Hours Spent Justification"].to_s
     hours = payload["Optional - Override Hours Spent"]
     project = item.project
-    kind = project&.build_review? ? "hardware/build (journaling + timelapse, not Hackatime)" : "software (Hackatime-tracked)"
+    kind = project&.build_review? ? "build review (journaling + timelapse, not Hackatime)" : "design review (Hackatime-tracked)"
 
     <<~PROMPT
       You are auditing a Hack Club Forge "Override Hours Spent Justification" before it enters the YSWS Unified Database. This text is an INTERNAL reviewer record. Judge ONLY the justification text against the standard below — do not re-review the project itself.
 
       ## The standard — a compliant justification must
       1. Specific and verifiable — cite concrete numbers and links another reviewer could independently check.
-      2. Time evidence stated — for software, the Hackatime project name + the date range analysed + a summary of what the data shows; for hardware, journaling + timelapse evidence.
+      2. Time evidence stated — for a design review, the Hackatime project name + the date range analysed + a summary of what the data shows; for a build review, journaling + timelapse evidence.
       3. Hour adjustment documented — if approved hours are lower than claimed, it states the claimed hours, the approved hours, and the reason for the deflation.
       4. Scope justified — explains what was built and why the scope is consistent with the approved hours.
       5. Factual internal record — NOT encouragement, praise, or a message addressed to the submitter.


### PR DESCRIPTION
review view timeline now shows past internal justifications, tier changes, and coin amounts. admin-only, public timeline untouched. also carries 2 small justification fixes that missed #314.