### PR TITLE
fix impersonation blocking submissions

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -7,7 +7,7 @@ module Authentication
       before_action :set_current_user
       before_action :authenticate_user!
       before_action :redirect_banned_user!
-      before_action :block_writes_while_impersonating!
+      before_action :block_money_actions_while_impersonating!
       helper_method :current_user, :user_signed_in?, :true_user, :impersonating?
   end
 
@@ -56,22 +56,20 @@ module Authentication
     session[:impersonator_id].present?
   end
 
-  # While impersonating, the session is strictly read/QA: block every state-changing
-  # request (anything but GET/HEAD) so an admin can never act as the impersonated user
-  # — no orders, coin spends, submissions, profile edits, nothing. The only writes
-  # allowed are stopping impersonation and signing out.
-  def block_writes_while_impersonating!
+  # While impersonating, an admin may act on the user's behalf (submit projects,
+  # edit, log devlogs) but must NEVER spend the user's coins. Shop orders are the
+  # only user-facing money action; admin money actions stay unreachable because
+  # the impersonated user isn't staff.
+  def block_money_actions_while_impersonating!
     return unless impersonating?
-    return if request.get? || request.head?
-    return if controller_name == "impersonations" && action_name == "destroy"
-    return if controller_name == "auth" && action_name == "destroy"
+    return unless controller_name == "shop" && action_name == "create"
 
     if request.format.json? || request.xhr?
       head :forbidden
     else
-      redirect_back fallback_location: root_path,
+      redirect_back fallback_location: shop_path,
                     status: :see_other,
-                    alert: "You're viewing as another user — stop impersonating to make changes."
+                    alert: "You can't spend a user's coins while viewing as them — stop impersonating first."
     end
   end
 

--- a/app/controllers/impersonations_controller.rb
+++ b/app/controllers/impersonations_controller.rb
@@ -1,7 +1,8 @@
-# Lets a user-admin browse the app as another (non-staff) user for QA/support.
-# The real admin's id is parked in session[:impersonator_id]; the session is
-# read-only while impersonating (see Authentication#block_writes_while_impersonating!),
-# so no actions — money or otherwise — can be taken as the impersonated user.
+# Lets a user-admin act as another (non-staff) user for support — submitting or
+# fixing things on their behalf. The real admin's id is parked in
+# session[:impersonator_id]. Spending the user's coins is blocked (see
+# Authentication#block_money_actions_while_impersonating!); admin actions stay
+# unreachable since the impersonated user isn't staff.
 class ImpersonationsController < ApplicationController
   before_action :require_impersonation_permission!, only: :create
 

--- a/app/javascript/components/ImpersonationBanner.tsx
+++ b/app/javascript/components/ImpersonationBanner.tsx
@@ -17,7 +17,7 @@ export default function ImpersonationBanner() {
         {impersonation.impersonator && (
           <span className="hidden sm:inline text-fuchsia-200/80"> · you are {impersonation.impersonator}</span>
         )}
-        <span className="ml-2 hidden md:inline text-xs text-fuchsia-200/70">read-only — changes are blocked</span>
+        <span className="ml-2 hidden md:inline text-xs text-fuchsia-200/70">acting on their behalf · can't spend their coins</span>
       </span>
       <button
         onClick={stop}

--- a/test/controllers/impersonations_controller_test.rb
+++ b/test/controllers/impersonations_controller_test.rb
@@ -47,18 +47,31 @@ class ImpersonationsControllerTest < ActionDispatch::IntegrationTest
     assert_nil session[:impersonator_id]
   end
 
-  test "state-changing requests are blocked while impersonating" do
+  test "spending the user's coins is blocked while impersonating" do
     admin = admin_with_users_permission
     target = make_user
-    other = make_user
     sign_in_as(admin)
     post impersonate_path(target)
 
-    post impersonate_path(other), headers: { "Accept" => "application/json" }
+    assert_no_difference -> { Order.count } do
+      post shop_orders_path, params: { kind: "direct_grant", amount_usd: 5 }, headers: { "Accept" => "application/json" }
+    end
     assert_response :forbidden
-    # Session is untouched — still impersonating the original target.
+    # Session is untouched — still impersonating.
     assert_equal target.id, session[:user_id]
     assert_equal admin.id, session[:impersonator_id]
+  end
+
+  test "non-money actions are allowed while impersonating" do
+    admin = admin_with_users_permission
+    target = make_user
+    sign_in_as(admin)
+    post impersonate_path(target)
+
+    # A non-coin-spending shop action (and, by extension, submitting/editing) is
+    # not blocked by the money guard — it falls through to the controller.
+    patch shop_region_path, params: { region: "us" }
+    assert_not_equal 403, response.status
   end
 
   test "cannot impersonate staff members" do


### PR DESCRIPTION
Impersonation blocked all writes, so submitting a project (+ its AI check) on a user's behalf got stuck. Now only coin spending (shop checkout) is blocked while impersonating; everything else goes through.