### PR TITLE
add HCB budget metric

### DIFF
--- a/app/controllers/admin/metrics_controller.rb
+++ b/app/controllers/admin/metrics_controller.rb
@@ -183,7 +183,8 @@ class Admin::MetricsController < Admin::ApplicationController
       reel_economy: reel_economy,
       location_distribution: location_distribution,
       reviews: review_stats,
-      shop_economy: shop_economy
+      shop_economy: shop_economy,
+      budget: HcbService.summary
     }
   end
 

--- a/app/javascript/pages/Admin/Metrics/Index.tsx
+++ b/app/javascript/pages/Admin/Metrics/Index.tsx
@@ -80,6 +80,13 @@ interface ShopEconomy {
   orders_count: number
 }
 
+interface Budget {
+  balance_usd: number
+  incoming_usd: number
+  total_raised_usd: number
+  org_url: string
+}
+
 interface ReviewStats {
   completed: number
   avg_active_seconds: number
@@ -182,6 +189,7 @@ export default function AdminMetricsIndex({
   location_distribution,
   reviews,
   shop_economy,
+  budget,
 }: {
   range_days: number
   summary: Summary
@@ -197,6 +205,7 @@ export default function AdminMetricsIndex({
   location_distribution: LocationDistribution
   reviews: ReviewStats
   shop_economy: ShopEconomy
+  budget: Budget | null
 }) {
   const max = Math.max(1, ...daily.map((d) => d.count))
   const maxHours = Math.max(1, ...daily_hours.map((d) => d.hours))
@@ -361,6 +370,34 @@ export default function AdminMetricsIndex({
             hint={`builder submit until decided · n=${reviews.turnaround_sample}`}
           />
         </div>
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-sm font-semibold tracking-wide uppercase text-muted-foreground">Budget — HCB</h2>
+        {budget ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            <Stat
+              label="Available budget"
+              value={`$${budget.balance_usd.toLocaleString()}`}
+              hint="real HCB funds · excludes coins"
+              accent
+            />
+            <Stat
+              label="Incoming (pending)"
+              value={`$${budget.incoming_usd.toLocaleString()}`}
+              hint="transfers not yet settled"
+            />
+            <Stat
+              label="Total raised"
+              value={`$${budget.total_raised_usd.toLocaleString()}`}
+              hint="lifetime into HCB"
+            />
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="p-4 text-sm text-muted-foreground">Couldn&apos;t reach HCB right now.</CardContent>
+          </Card>
+        )}
       </div>
 
       <div className="space-y-2">

--- a/app/services/hcb_service.rb
+++ b/app/services/hcb_service.rb
@@ -1,0 +1,49 @@
+require "net/http"
+require "json"
+
+module HcbService
+  module_function
+
+  ORG_SLUG = ENV.fetch("HCB_ORG_SLUG", "forge")
+  API_BASE = "https://hcb.hackclub.com/api/v3".freeze
+  OPEN_TIMEOUT = 5
+  READ_TIMEOUT = 10
+
+  def summary
+    org = fetch_org
+    return nil unless org.is_a?(Hash)
+
+    balances = org["balances"] || {}
+    {
+      balance_usd: cents_to_usd(balances["balance_cents"]),
+      incoming_usd: cents_to_usd(balances["incoming_balance_cents"]),
+      total_raised_usd: cents_to_usd(balances["total_raised"]),
+      org_url: "https://hcb.hackclub.com/#{ORG_SLUG}"
+    }
+  end
+
+  def fetch_org
+    Rails.cache.fetch("hcb/org/#{ORG_SLUG}", expires_in: 5.minutes, skip_nil: true) do
+      get_org
+    end
+  end
+
+  def get_org
+    uri = URI("#{API_BASE}/organizations/#{ORG_SLUG}")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.open_timeout = OPEN_TIMEOUT
+    http.read_timeout = READ_TIMEOUT
+    response = http.get(uri.request_uri, "Accept" => "application/json")
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
+  rescue StandardError => e
+    Rails.logger.error("HcbService failed: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def cents_to_usd(cents)
+    (cents.to_i / 100.0).round(2)
+  end
+end


### PR DESCRIPTION
Adds a read-only Budget section to the admin Metrics page that pulls the forge org's available balance from HCB's public API (cached, no token). Shows real HCB funds (excludes coins), plus pending incoming and total raised.