### PR TITLE
admin: convert project between design and build

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -158,6 +158,22 @@ class Admin::ProjectsController < Admin::ApplicationController
     redirect_to admin_project_path(@project), notice: "Tier changed from #{old_tier.tr('_', ' ')} to #{new_tier.tr('_', ' ')}."
   end
 
+  def convert_review_type
+    authorize @project, :review?
+
+    if @project.build_review?
+      @project.update!(build_review: false, tier: Project::TIERS.last, linked_project_id: nil)
+      audit!("project.review_type_changed", target: @project, metadata: { to: "design" })
+      redirect_to admin_review_path(@project), notice: "Converted to a design review."
+    else
+      @project.update!(build_review: true, tier: Project::BUILD_REVIEW_TIER, linked_project_id: nil)
+      audit!("project.review_type_changed", target: @project, metadata: { to: "build" })
+      redirect_to admin_review_path(@project), notice: "Converted to a build review."
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to admin_review_path(@project), alert: "Couldn't convert: #{e.record.errors.full_messages.to_sentence}"
+  end
+
   def reverse_review
     authorize @project, :review?
 

--- a/app/javascript/components/admin/review/DecisionPanel.tsx
+++ b/app/javascript/components/admin/review/DecisionPanel.tsx
@@ -54,6 +54,7 @@ export function DecisionPanel({
   onRejectOpenChange,
   onSubmit,
   onChangeTier,
+  onConvertReviewType,
   onOpenCheckpoint,
   onOpenDm,
   onTrack,
@@ -74,6 +75,7 @@ export function DecisionPanel({
   onRejectOpenChange: (open: boolean) => void
   onSubmit: (decision: 'approve' | 'return' | 'reject' | 'draft') => void
   onChangeTier: (tier: string) => void
+  onConvertReviewType: () => void
   onOpenCheckpoint: () => void
   onOpenDm: () => void
   onTrack: (button: string, metadata?: Record<string, unknown>) => void
@@ -221,6 +223,14 @@ export function DecisionPanel({
           )}
         </div>
       )}
+
+      <button
+        type="button"
+        onClick={onConvertReviewType}
+        className="w-full h-9 rounded-md border border-border bg-background px-3 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors cursor-pointer"
+      >
+        {project.build_review ? 'Convert to design review' : 'Convert to build review'}
+      </button>
 
       <Separator />
 

--- a/app/javascript/pages/Admin/Reviews/Show.tsx
+++ b/app/javascript/pages/Admin/Reviews/Show.tsx
@@ -305,6 +305,18 @@ export default function AdminReviewsShow({
     [project.id, project.tier, track],
   )
 
+  const convertReviewType = useCallback(() => {
+    const toBuild = !project.build_review
+    if (
+      !confirm(
+        `Convert this to a ${toBuild ? 'build' : 'design'} review? It moves to the ${toBuild ? 'build' : 'design'} queue.`,
+      )
+    )
+      return
+    track('convert_review_type', { to: toBuild ? 'build' : 'design' })
+    router.post(`/admin/projects/${project.id}/convert_review_type`, {}, { preserveScroll: true })
+  }, [project.id, project.build_review, track])
+
   const submit = useCallback(
     (decision: 'approve' | 'return' | 'reject' | 'draft') => {
       track(`${decision}_clicked`)
@@ -623,6 +635,7 @@ export default function AdminReviewsShow({
                 onRejectOpenChange={setRejectOpen}
                 onSubmit={submit}
                 onChangeTier={changeTier}
+                onConvertReviewType={convertReviewType}
                 onOpenCheckpoint={openCheckpoint}
                 onOpenDm={openDm}
                 onTrack={track}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,6 +254,7 @@ Rails.application.routes.draw do
           post :toggle_shadow_ban
           post :toggle_staff_pick
           post :change_tier
+          post :convert_review_type
           post :add_note
           post :mark_unbuilt
           post :reverse_review


### PR DESCRIPTION
Adds a Convert to build/design review button on the admin review screen. Flips the project's type in place (sets build_review + the required tier), clears any stale link, and is audited.