### PR TITLE
fix devlogs disappearing when a project is converted to tier 1

### DIFF
--- a/app/javascript/pages/Projects/Show.tsx
+++ b/app/javascript/pages/Projects/Show.tsx
@@ -613,7 +613,7 @@ export default function ProjectsShow({
   const isPending = project.status === 'pending'
   const isReturned = project.status === 'returned'
   const isBuildingPhase =
-    isPitchApproved || isApproved || isPending || isReturned || (project.status === 'draft' && isNormalTier)
+    isPitchApproved || isApproved || isPending || isReturned || (project.status === 'draft' && (isNormalTier || devlogs.length > 0))
   const isGitMode = project.devlog_mode === 'git'
   const isWebMode = project.devlog_mode === 'website'
   const canLog = isBuildingPhase


### PR DESCRIPTION
converting a draft project to tier 1 was hiding all its existing devlogs, since a tier 1 draft isn't counted as 'building phase'. now a draft stays in building phase if it already has devlogs, so a tier change can't hide them.