### PR TITLE
Fixed the built filter in the explore page

### DIFF
--- a/app/controllers/concerns/explore_feed_props.rb
+++ b/app/controllers/concerns/explore_feed_props.rb
@@ -16,7 +16,7 @@ module ExploreFeedProps
     else                    scope
     end
 
-    ranked = scope.fair_feed
+    ranked = Project.fair_feed(scope)
     ranked = ranked.partition { |p| p.cover_image_url.present? }.flatten
 
     pagy_obj, projects = pagy(ranked)

--- a/app/controllers/concerns/explore_feed_props.rb
+++ b/app/controllers/concerns/explore_feed_props.rb
@@ -8,7 +8,7 @@ module ExploreFeedProps
   def explore_feed_props
     filter = FILTERS.include?(params[:filter]) ? params[:filter] : "all"
 
-    scope = Project.kept.where(hidden: false).includes(:user, :ships)
+    scope = Project.kept.where(hidden: false).not_shadow_banned.includes(:user, :ships)
     scope = scope.search(params[:query]) if params[:query].present?
     scope = case filter
     when "in_progress" then scope.where(status: :approved, built_at: nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -132,8 +132,8 @@ class Project < ApplicationRecord
   # excluded from the public leaderboard and admin metrics aggregates.
   scope :not_shadow_banned, -> { where(shadow_banned: false) }
 
-  def self.fair_feed
-    all.sort_by { |p| -p.feed_score }
+  def self.fair_feed(scope = all)
+    scope.to_a.sort_by { |p| -p.feed_score }
   end
 
   def feed_score


### PR DESCRIPTION
I was looking at the forge site, and i saw that the built filter was not working properly. i decided to fix it 
<img width="1529" height="1013" alt="image" src="https://github.com/user-attachments/assets/3b4f5926-82a4-47a2-8337-e725fe789c1c" />
i did code changes and uploaded some tests on localhost to verify.
It should work fine now.
