### PR TITLE
Show actual payout breakdown on approved projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -436,6 +436,7 @@ class ProjectsController < ApplicationController
       review_feedback: can_view_private_project_data ? project.review_feedback : nil,
       tier: project.tier,
       coin_rate: project.coin_rate,
+      payout: can_view_private_project_data ? serialize_payout(project) : nil,
       from_slack: project.slack_message_ts.present?,
       cover_image_url: project.cover_image_url,
       built_at: project.built_at&.strftime("%b %d, %Y"),
@@ -465,6 +466,31 @@ class ProjectsController < ApplicationController
 
   def can_view_project_review?(project)
     current_user.present? && (project.member?(current_user) || current_user.staff?)
+  end
+
+  def serialize_payout(project)
+    return nil unless project.approved?
+
+    share = current_user && project.project_payouts.find_by(user_id: current_user.id)
+    if share
+      {
+        hours: share.hours.to_f,
+        logged_hours: project.devlogs.where(user_id: current_user.id).sum(&:parsed_hours).to_f.round(2),
+        coins: share.coins.to_f,
+        streak_multiplier: share.streak_multiplier&.to_f,
+        guild_multiplier: share.guild_multiplier&.to_f,
+        team_total: project.coins_earned
+      }
+    else
+      {
+        hours: project.total_hours.to_f.round(2),
+        logged_hours: project.devlog_hours.to_f.round(2),
+        coins: project.coins_earned,
+        streak_multiplier: project.streak_at_approval && project.user.streak_multiplier(project.streak_at_approval),
+        guild_multiplier: nil,
+        team_total: nil
+      }
+    end
   end
 
   def serialize_members(project)

--- a/app/javascript/pages/Projects/Show.tsx
+++ b/app/javascript/pages/Projects/Show.tsx
@@ -1636,7 +1636,38 @@ export default function ProjectsShow({
               Link Repository
             </button>
           )}
-          {can.update && !is_admin_view && totalHours > 0 && project.status !== 'rejected' && (
+          {can.update && !is_admin_view && project.payout && (
+            <div className="bg-[#1c1b1b] ghost-border p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="material-symbols-outlined text-[#ffb595] text-base">paid</span>
+                <h4 className="text-xs font-bold uppercase tracking-[0.2em] text-stone-500 font-headline">
+                  {project.payout.team_total !== null ? 'Your Payout' : 'Payout'}
+                </h4>
+              </div>
+              <p className="text-4xl font-headline font-bold text-[#ffb595] tracking-tight">
+                {project.payout.coins.toFixed(2)}
+                <span className="text-xl text-stone-500 ml-1">c</span>
+              </p>
+              <div className="mt-3 space-y-1 text-xs text-stone-500">
+                <p>
+                  {project.payout.hours}h approved
+                  {project.payout.logged_hours !== project.payout.hours &&
+                    ` (${project.payout.logged_hours}h logged)`}{' '}
+                  × {project.coin_rate}c/h
+                </p>
+                {project.payout.streak_multiplier !== null && project.payout.streak_multiplier !== 1 && (
+                  <p>× {project.payout.streak_multiplier} streak multiplier</p>
+                )}
+                {project.payout.guild_multiplier !== null && project.payout.guild_multiplier !== 1 && (
+                  <p>× {project.payout.guild_multiplier} guild multiplier</p>
+                )}
+                {project.payout.team_total !== null && (
+                  <p>Team total: {project.payout.team_total.toFixed(2)}c</p>
+                )}
+              </div>
+            </div>
+          )}
+          {can.update && !is_admin_view && totalHours > 0 && project.status !== 'rejected' && !project.payout && (
             <div className="bg-[#1c1b1b] ghost-border p-6">
               <div className="flex items-center gap-2 mb-3">
                 <span className="material-symbols-outlined text-[#ffb595] text-base">paid</span>

--- a/app/javascript/types/index.ts
+++ b/app/javascript/types/index.ts
@@ -93,6 +93,15 @@ export interface ProjectMember {
   collaborator_id: number | null
 }
 
+export interface ProjectPayout {
+  hours: number
+  logged_hours: number
+  coins: number
+  streak_multiplier: number | null
+  guild_multiplier: number | null
+  team_total: number | null
+}
+
 export interface ProjectDetail {
   id: number
   name: string
@@ -107,6 +116,7 @@ export interface ProjectDetail {
   ai_usage: string | null
   tier: ProjectTier
   coin_rate: number
+  payout: ProjectPayout | null
   from_slack: boolean
   cover_image_url: string | null
   built_at: string | null


### PR DESCRIPTION
Users couldn't see their approved hours or multipliers, so payouts looked wrong whenever a reviewer overrode hours (see the streak multiplier ticket). Approved projects now show members the real breakdown — approved vs logged hours, streak/guild multipliers, and group shares — instead of the devlog-based estimate.